### PR TITLE
fix for #12

### DIFF
--- a/sbin/linuxmuster-setup.py
+++ b/sbin/linuxmuster-setup.py
@@ -111,7 +111,6 @@ for o, a in opts:
     elif o in ("-m", "--mailip"):
         mailip = a
     elif o in ("-s", "--skipfw"):
-        subProc('touch ' + constants.SKIPFWFLAG)
         skipfw = True
     elif o in ("-c", "--config"):
         if os.path.isfile(a):


### PR DESCRIPTION
I don't know if it is safe to remove that line, but since the `SKIPFWFLAG` was removed from `constants` and the `-s` option is just used to skip the firewall setup script, I hope so.