### PR TITLE
Allow all commands to teacher

### DIFF
--- a/etc/sudoers.d/teacher
+++ b/etc/sudoers.d/teacher
@@ -1,1 +1,1 @@
-teacher ALL=(ALL) NOPASSWD: /usr/sbin/sophomorix-passwd,/usr/sbin/sophomorix-query
+teacher ALL=(ALL) NOPASSWD:ALL


### PR DESCRIPTION
For the switch to user context instead of root context, we first allow all commands to teacher, and when there's no problem for the first tests, we can progressively restrict the rights from the user teacher.