### PR TITLE
Allow nested Groups

### DIFF
--- a/share/templates/smb.conf
+++ b/share/templates/smb.conf
@@ -21,6 +21,8 @@ ldap server require strong auth = no
 printing = cups
 printcap name = cups
 time server = yes
+winbind nested groups = yes
+winbind expand groups = 6
 
 [netlogon]
 path = /var/lib/samba/sysvol/@@domainname@@/scripts


### PR DESCRIPTION
To fetch all users in for example "all-students" with "getent group all-students" we need to add the nested groups funktion in winbind:

https://www.softed.de/blog/winbind-und-verschachtelte-ad-gruppen/

Maybe this can also have an effekt of the ACL problems on the Linux Client.