### PR TITLE
Add Server string to remove version exposement

### DIFF
--- a/share/templates/smb.conf
+++ b/share/templates/smb.conf
@@ -12,6 +12,7 @@ workgroup = @@sambadomain@@
 realm = @@realm@@
 netbios name = @@netbiosname@@
 server role = active directory domain controller
+server string = Linuxmuster.net Dateiserver
 dns forwarder = @@firewallip@@
 registry shares = yes
 host msdfs = yes


### PR DESCRIPTION
Its better to remove the default Samba version string because the students better dont know what version of Samba is running. Thats a little bit more secure.