### PR TITLE
Fix dhcp in multi schools and add maintenance table

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,14 @@
 Management scripts for linuxmuster.net V7
 
 Further information is available in the [Wiki](https://github.com/linuxmuster/linuxmuster-base7/wiki).
+
+## Maintainance Details
+    
+Linuxmuster.net official | ![#c5f015](https://via.placeholder.com/15/c5f015/000000?text=+)  YES
+:---: | :---: 
+[Community support](https://ask.linuxmuster.net) | ![#c5f015](https://via.placeholder.com/15/c5f015/000000?text=+)  YES**
+Actively developed | ![#c5f015](https://via.placeholder.com/15/c5f015/000000?text=+)  YES
+Maintainer organisation |  Linuxmuster.net e.V.  
+Primary maintainer | thomas@linuxmuster.net  
+  
+** The linuxmuster community consits of people who are nice and happy to help. They are not directly involved in the development though, and might not be able to help in any case.

--- a/sbin/linuxmuster-import-devices
+++ b/sbin/linuxmuster-import-devices
@@ -16,6 +16,7 @@ import getopt
 
 from os import listdir
 from os.path import isfile, join
+from pathlib import Path
 
 from functions import getBootImage, getDevicesArray, getGrubOstype, getGrubPart
 from functions import getSetupValue, getStartconfOsValues, getStartconfOption
@@ -214,11 +215,17 @@ def writeDhcpDevicesConfig(school='default-school'):
   option host-name "@@hostname@@";
   hardware ethernet @@mac@@;
 """
-    cfgfile = constants.DHCPDEVCONF
+    baseConfigFilePath = constants.DHCPDEVCONF
+    devicesConfigBasedir = "/etc/dhcp/devices"
+    Path(devicesConfigBasedir).mkdir(parents=True, exist_ok=True)
+
+    cfgfile = devicesConfigBasedir + "/" + school + ".conf"
     if os.path.isfile(cfgfile):
         os.unlink(cfgfile)
+    if os.path.isfile(baseConfigFilePath):
+        os.unlink(baseConfigFilePath)
     try:
-        # open devices.conf for append
+        # open devices/<school>.conf for append
         with open(cfgfile, 'a') as outfile:
             # iterate over the defined subnets
             subnets = getSubnetArray('0')
@@ -275,6 +282,12 @@ def writeDhcpDevicesConfig(school='default-school'):
                     host_decl = host_decl + '}\n'
                     # finallý write host declaration
                     outfile.write(host_decl)
+    
+        # open devices.conf for append
+        with open(baseConfigFilePath, 'a') as outfile:
+            for devicesConf in listdir(devicesConfigBasedir):
+                outfile.write("include \"{0}/{1}\";\n".format(devicesConfigBasedir, devicesConf))
+
     except Exception as error:
         print(error)
         return False


### PR DESCRIPTION
This PR adds the maintenance table and slightly changes the approach on DHCP configuration:
- The devices are now specified in a file in /etc/dhcp/devices/<school>.conf separate for each school
- All the school devices confs are included in /etc/dhcp/devices.conf
- This makes it possible to update the config of one school without overwriting the conf of another school.