### PR TITLE
Escape dollar in regexp

### DIFF
--- a/lib/functions.py
+++ b/lib/functions.py
@@ -961,7 +961,7 @@ def isValidPassword(password):
     # searching for lowercase
     lowercase_error = re.search(r"[a-z]", password) is None
     # no $ in pw
-    unwanted_error = re.search(r"$", password) is not None
+    unwanted_error = re.search(r"\$", password) is not None
     # searching for symbols
     if digit_error is True:
         digit_error = False


### PR DESCRIPTION
`re.search(r"\$", password) is not None` will return `True` on each password string, which will block the setup process. 

See https://ask.linuxmuster.net/t/bei-lmn71-setup-there-is-no-admin-passwort/8911