### PR TITLE
No log for sophomorix-passwd

### DIFF
--- a/share/templates/webui-sudoers
+++ b/share/templates/webui-sudoers
@@ -10,3 +10,6 @@
 %@@sambadomain@@\\role-teacher ALL=(ALL:ALL) NOPASSWD:ALL
 %@@sambadomain@@\\role-globaladministrator ALL=(ALL:ALL) NOPASSWD:ALL
 %@@sambadomain@@\\role-schooladministrator ALL=(ALL:ALL) NOPASSWD:ALL
+
+Cmnd_Alias SOPHPASS = /usr/sbin/sophomorix-passwd
+Defaults!SOPHPASS !syslog


### PR DESCRIPTION
Run with sudo, passwords given to sophomorix-passwd are shown in /var/log/auth.log.
The option !syslog permit to override this behaviour.

@PLanB2008 : can you please have a look at this too ?

It's related to the following issue : https://github.com/linuxmuster/linuxmuster-webui7/issues/236