### PR TITLE
Add school parameter for hook scripts

### DIFF
--- a/sbin/linuxmuster-import-devices
+++ b/sbin/linuxmuster-import-devices
@@ -374,7 +374,7 @@ if len(hookscripts) > 0:
         hookscript = hookpath + '/' + h
         msg = '* ' + h + ' '
         printScript(msg, '', False, False, True)
-        output = subprocess.check_output(hookscript).decode('utf-8')
+        output = subprocess.check_output([hookscript, "-s", school]).decode('utf-8')
         if output != '':
             print(output)
 


### PR DESCRIPTION
In order to be able to use the hook scripts effectively in a multi-school environment, it would be good if the school was passed as a parameter when calling the hook scripts.