### PR TITLE
Fix SSLDIR var

### DIFF
--- a/lib/functions.py
+++ b/lib/functions.py
@@ -544,9 +544,9 @@ def createServerCert(item, days, logfile):
     keyfile = constants.SSLDIR + '/' + item + '.key.pem'
     certfile = constants.SSLDIR + '/' + item + '.cert.pem'
     if item == 'firewall':
-        cnffile = environment.SSLDIR + '/' + item + '_cert_ext.cnf'
+        cnffile = constants.SSLDIR + '/' + item + '_cert_ext.cnf'
     else:
-        cnffile = environment.SSLDIR + '/server_cert_ext.cnf'
+        cnffile = constants.SSLDIR + '/server_cert_ext.cnf'
     fullchain = constants.SSLDIR + '/' + item + '.fullchain.pem'
     subj = '-subj /CN=' + fqdn + '/'
     shadays = ' -sha256 -days ' + days


### PR DESCRIPTION
linuxmuster-common is not installed in 7.2, so the environment library is not available, and cause the setup to fail.