### PR TITLE
linuxmuster-release-upgrade: fix #186, don't destroy resolv.conf if backup already restored

### DIFF
--- a/sbin/linuxmuster-release-upgrade
+++ b/sbin/linuxmuster-release-upgrade
@@ -2,7 +2,7 @@
 #
 # This script performs a release upgrade to linuxmuster.net 7.4.
 # thomas@linuxmuster.net
-# 20260709
+# 20260723
 #
 
 # get linuxmuster environment

--- a/sbin/linuxmuster-release-upgrade
+++ b/sbin/linuxmuster-release-upgrade
@@ -186,8 +186,10 @@ rm -f /etc/apt/apt.conf.d/local
 
 # restore resolv.conf
 echo -e "\n## Restoring resolv.conf..."
-rm -f /etc/resolv.conf
-mv /etc/resolv.conf.release-upgrade /etc/resolv.conf
+if [ -f /etc/resolv.conf.release-upgrade ]; then
+    rm -f /etc/resolv.conf
+    mv /etc/resolv.conf.release-upgrade /etc/resolv.conf
+fi
 
 # reboot
 if [ -n "$autoreboot" ]; then


### PR DESCRIPTION
## Summary
- Fixes #186: `linuxmuster-release-upgrade` deleted `/etc/resolv.conf` on the final restore step whenever the earlier restore (right after `do-release-upgrade`) had already consumed the `/etc/resolv.conf.release-upgrade` backup, leaving the server without DNS resolution after a migration.
- The final restore block now only removes/replaces `/etc/resolv.conf` if the backup file still exists.

## Test plan
- [ ] Reproduced on a v7.3 -> v7.4 migration test VM: prior to the fix, `/etc/resolv.conf` was missing after the script finished (confirmed via `ls`/`cat` right after the run).
- [ ] With the fix applied, `/etc/resolv.conf` retains the content restored by the earlier restore step and is left untouched by the final block.