### PR TITLE
Remove deprecated syslog command

### DIFF
--- a/share/templates/webui-sudoers
+++ b/share/templates/webui-sudoers
@@ -10,6 +10,3 @@
 %@@sambadomain@@\\role-teacher ALL=(ALL:ALL) NOPASSWD:ALL
 %@@sambadomain@@\\role-globaladministrator ALL=(ALL:ALL) NOPASSWD:ALL
 %@@sambadomain@@\\role-schooladministrator ALL=(ALL:ALL) NOPASSWD:ALL
-
-Cmnd_Alias SOPHPASS = /usr/sbin/sophomorix-passwd
-Defaults!SOPHPASS !syslog


### PR DESCRIPTION
Since Ubuntu 26.04 uses `sudo-rs` instead of the legacy `sudo`, the parameter to avoid logging into `syslog` is not valid anymore. We must find another solution for this.