### PR TITLE
fix(ntp.conf): drop obsolete notrap restrict flag

### DIFF
--- a/share/templates/ntp.conf
+++ b/share/templates/ntp.conf
@@ -1,7 +1,7 @@
 # /etc/ntpsec/ntp.conf
 #
 # thomas@linuxmuster.net
-# 20250721
+# 20260814
 #
 # configuration for ntpd; see ntp.conf(5) for help
 
@@ -11,10 +11,10 @@ filegen loopstats file loopstats type day enable
 filegen peerstats file peerstats type day enable
 filegen clockstats file clockstats type day enable
 server @@firewallip@@ iburst prefer
-restrict -4 default kod notrap nomodify nopeer noquery limited mssntp
-restrict -6 default kod notrap nomodify nopeer noquery limited mssntp
+restrict -4 default kod nomodify nopeer noquery limited mssntp
+restrict -6 default kod nomodify nopeer noquery limited mssntp
 @@restricted_subnets@@
 restrict 127.0.0.1
 restrict ::1
-restrict source notrap nomodify noquery
+restrict source nomodify noquery
 ntpsigndsocket @@ntpsockdir@@


### PR DESCRIPTION
## What

Drop the obsolete `notrap` flag from all three `restrict` lines in
`share/templates/ntp.conf`, and bump the template's version-comment date so
`linuxmuster-update-ntpconf` (postinst) picks up the change on existing
installs.

## Why

ntpsec removed NTP mode-7 (the control-message trap/`mrulist` service) for
security reasons. `notrap` configures exactly that removed mechanism, so
ntpsec parses it for `ntp.conf`-syntax compatibility but ignores it, logging
on every `ntpd` start:

```
CONFIG: restrict notrap ignored
```

three times per start (matches each `restrict` line it appears on). Harmless,
but shows up as log-monitoring noise on every server running the standard
ntpsec config (confirmed on a 7.4 host, `journalctl -u ntpsec.service`).

## Change

```diff
- restrict -4 default kod notrap nomodify nopeer noquery limited mssntp
- restrict -6 default kod notrap nomodify nopeer noquery limited mssntp
+ restrict -4 default kod nomodify nopeer noquery limited mssntp
+ restrict -6 default kod nomodify nopeer noquery limited mssntp
  @@restricted_subnets@@
  restrict 127.0.0.1
  restrict ::1
- restrict source notrap nomodify noquery
+ restrict source nomodify noquery
```

## Testing

- Verified the resulting `ntp.conf` still starts `ntpsec.service` cleanly with
  no `CONFIG: ... ignored` lines in the journal.
- No other functional change: `notrap` was already a no-op under ntpsec, so
  restriction behavior (kod/nomodify/nopeer/noquery/limited/mssntp) is
  unchanged.

Fixes #192.
